### PR TITLE
Auto-random teams and admin only brokenq

### DIFF
--- a/.github/workflows/BuildNorm.yml
+++ b/.github/workflows/BuildNorm.yml
@@ -5,7 +5,7 @@ name: Build Norm Executable
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/LintCode.yml
+++ b/.github/workflows/LintCode.yml
@@ -5,9 +5,9 @@ name: Lint Project Files
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [main]
 
-jobs:  
+jobs:
   build:
     name: Verify Python files pass linting
     runs-on: ubuntu-latest

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -1,9 +1,48 @@
 from CheckForUpdates import updateBot
-from EmbedHelper import AdminEmbed, ErrorEmbed
+from EmbedHelper import AdminEmbed, ErrorEmbed, QueueUpdateEmbed
 from typing import List
 from bot import __version__
 from discord import Role, Embed, Member
 import Queue
+from Leaderboard import brokenQueue as breakQueue
+
+
+def brokenQueue(roles: List[Role], mentions: List[Member]) -> Embed:
+    """
+        Removes the active match that the author is in.
+
+        Parameters:
+            roles: List[discord.Role] - The roles of the author of the message.
+            mentions: List[dicord.Member] - The list of members mentioned in the message.
+
+        Returns:
+            dicord.Embed - The embedded message to respond with.
+    """
+
+    if (Queue.isBotAdmin(roles)):
+        if (len(mentions) != 1):
+            return ErrorEmbed(
+                title="Could Not Remove Queue",
+                desc="You must mention one player who is in the match you want to remove."
+            )
+        else:
+            msg = breakQueue(mentions[0])
+
+            if (":white_check_mark:" in msg):
+                return QueueUpdateEmbed(
+                    title="Popped Queue Removed",
+                    desc="The popped queue has been removed from active matches. You may now re-queue."
+                )
+
+            return ErrorEmbed(
+                title="Could Not Remove Queue",
+                desc=msg
+            )
+    else:
+        return AdminEmbed(
+            title="Permission Denied",
+            desc="You do not have the strength to break queues. Ask an admin if you need to break a queue."
+        )
 
 
 def update(roles: List[Role]) -> Embed:

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -9,7 +9,7 @@ from Leaderboard import brokenQueue as breakQueue
 
 def brokenQueue(roles: List[Role], mentions: List[Member]) -> Embed:
     """
-        Removes the active match that the author is in.
+        Removes the active match that the mentioned player is in.
 
         Parameters:
             roles: List[discord.Role] - The roles of the author of the message.
@@ -31,7 +31,7 @@ def brokenQueue(roles: List[Role], mentions: List[Member]) -> Embed:
             if (":white_check_mark:" in msg):
                 return QueueUpdateEmbed(
                     title="Popped Queue Removed",
-                    desc="The popped queue has been removed from active matches. You may now re-queue."
+                    desc="The popped queue has been removed from active matches."
                 )
 
             return ErrorEmbed(

--- a/src/Commands/SixMans.py
+++ b/src/Commands/SixMans.py
@@ -95,16 +95,11 @@ def playerQueue(player: Member, reportChannelId: int, *arg, quiet: bool = False)
 
     if (queue_length == 5):
         Queue.addToQueue(player, queueTime)
-        mentionedPlayerList = Queue.getQueueList(mentionPlayers=True, separator=", ")
 
-        return [QueueUpdateEmbed(
-            title="Queue Popped!",
-            desc=player.mention + " has been added to the queue for " + str(queueTime) + " minutes.\n\n"
-            "**Queue is now full!** \n\n"
-            "Type !random for random teams.\n"
-            "Type !captains to get picked last."
-        ),
-            "Queue has popped! Get ready!\n" + mentionedPlayerList]
+        mentionedPlayerList = Queue.getQueueList(mentionPlayers=True, separator=", ")
+        randomTeamsEmbed = random()
+
+        return [randomTeamsEmbed, "Queue has popped! Get ready!\n" + mentionedPlayerList]
 
     Queue.addToQueue(player, queueTime)
     playerList = Queue.getQueueList()
@@ -229,61 +224,34 @@ def captains(player: Member):
     )
 
 
-def random(player: Member):
+def random():
     """
         Pops the queue and randomly assigns players to teams.
-
-        Parameters:
-            player: dicord.Member - The author of the message.
 
         Returns:
             dicord.Embed - The embedded message to respond with.
     """
-    if (Queue.queueAlreadyPopped()):
-        return ErrorEmbed(
-            title="Captains Already Chosen",
-            desc="You cannot change your mind once you pick captains."
-        )
+    # if (Queue.queueAlreadyPopped()):
+    #     return ErrorEmbed(
+    #         title="Captains Already Chosen",
+    #         desc="You cannot change your mind once you pick captains."
+    #     )
 
-    if (Queue.getQueueLength() != 6):
-        return ErrorEmbed(
-            title="Queue is Not Full",
-            desc="You cannot pop a queue until is full."
-        )
+    # if (Queue.getQueueLength() != 6):
+    #     return ErrorEmbed(
+    #         title="Queue is Not Full",
+    #         desc="You cannot pop a queue until is full."
+    #     )
 
-    if (not Queue.isPlayerInQueue(player)):
-        return ErrorEmbed(
-            title="Not in Queue",
-            desc="You are not in the queue, therefore you cannot pop the queue."
-        )
+    # if (not Queue.isPlayerInQueue(player)):
+    #     return ErrorEmbed(
+    #         title="Not in Queue",
+    #         desc="You are not in the queue, therefore you cannot pop the queue."
+    #     )
 
     blueTeam, orangeTeam = Queue.randomPop()
     Leaderboard.startMatch(blueTeam, orangeTeam)
     return PlayersSetEmbed(blueTeam, orangeTeam)
-
-
-def brokenQueue(player: Member) -> Embed:
-    """
-        Removes the active match that the author is in.
-
-        Parameters:
-            player: dicord.Member - The author of the message.
-
-        Returns:
-            dicord.Embed - The embedded message to respond with.
-    """
-    msg = Leaderboard.brokenQueue(player)
-
-    if (":white_check_mark:" in msg):
-        return QueueUpdateEmbed(
-            title="Popped Queue Removed",
-            desc="The popped queue has been removed from active matches. You may now re-queue."
-        )
-
-    return ErrorEmbed(
-        title="Could Not Remove Queue",
-        desc=msg
-    )
 
 
 def leaderboard(author: Member, mentions: List[Member], lbChannelId: int, *arg) -> Embed:

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -30,7 +30,7 @@ def brokenQueue(player: Member) -> str:
     match = getActiveMatch(player)
 
     if (not match):
-        return "You are not in the queue; therefore you cannot report a broken queue."
+        return "The mentioned player is not in any active matches."
 
     if (match[MatchKey.REPORTED_WINNER][MatchKey.WINNING_TEAM] is not None):
         return "You cannot report a broken queue once someone reports the match."

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,11 +1,11 @@
-__author__ = "Caleb Smith / Twan / Matt Wells (Tux)"
-__copyright__ = "Copyright 2019, MIT License"
-__credits__ = "Caleb Smith / Twan / Matt Wells (Tux)"
+__author__ = "Matt Wells (Tux) / Austin Baker (h)"
+__copyright__ = "Copyright 2021, MIT License"
+__credits__ = "Matt Wells (Tux) / Austin Baker (h)"
 __license__ = "MIT"
-__version__ = "6.0.0"
-__maintainer__ = "Caleb Smith / Twan / Matt Wells (Tux)"
-__email__ = "caleb.benjamin9799@gmail.com / unavailable / mattwells878@gmail.com"
-
+__version__ = "1.0.0"
+__maintainer__ = "Matt Wells (Tux) / Austin Baker (h)"
+__email__ = "mattwells878@gmail.com / noise.9no@gmail.com"
+__credits__ = "Forked from https://github.com/ClamSageCaleb/UNCC-SIX-MANS to be modified for UNCC event with Dreamhack."
 
 import AWSHelper as AWS
 from DataFiles import getDiscordToken, updateDiscordToken, getChannelIds
@@ -44,7 +44,7 @@ LB_CHANNEL: discord.channel = None
 
 @client.event
 async def on_message(message: discord.Message):
-    isReport = "report" in message.content.lower()
+    isReport = "!report" in message.content.lower()
     if (message.author != client.user):
 
         if (
@@ -91,7 +91,7 @@ async def on_ready():
     try:
         channel = client.get_channel(QUEUE_CH_IDS[0])
         await channel.send(embed=AdminEmbed(
-            title="Norm Started",
+            title="Norm@Dreamhack Started",
             desc="Current version: v{0}".format(__version__)
         ))
     except Exception as e:
@@ -179,21 +179,21 @@ async def listq(ctx):
     await ctx.send(embed=SixMans.listQueue(ctx.message.author))
 
 
-@client.command(name='rnd', aliases=['random', 'idontwanttopickteams', 'fuckcaptains'], pass_context=True)
-async def random(ctx):
-    await ctx.send(embed=SixMans.random(ctx.message.author))
+# @client.command(name='rnd', aliases=['random', 'idontwanttopickteams', 'fuckcaptains'], pass_context=True)
+# async def random(ctx):
+#     await ctx.send(embed=SixMans.random(ctx.message.author))
 
 
-@client.command(name='captains', aliases=['cap', 'iwanttopickteams', 'Captains', 'captain', 'Captain', 'Cap'], pass_context=True)  # noqa
-async def captains(ctx):
-    await ctx.send(embed=SixMans.captains(ctx.message.author))
+# @client.command(name='captains', aliases=['cap', 'iwanttopickteams', 'Captains', 'captain', 'Captain', 'Cap'], pass_context=True)  # noqa
+# async def captains(ctx):
+#     await ctx.send(embed=SixMans.captains(ctx.message.author))
 
 
-@client.command(name='pick', aliases=['add', 'choose', '<:pick:628999871554387969>'], pass_context=True)
-async def pick(ctx):
-    embeds = SixMans.pick(ctx.message.author, ctx.message.mentions)
-    for embed in embeds:
-        await ctx.send(embed=embed)
+# @client.command(name='pick', aliases=['add', 'choose', '<:pick:628999871554387969>'], pass_context=True)
+# async def pick(ctx):
+#     embeds = SixMans.pick(ctx.message.author, ctx.message.mentions)
+#     for embed in embeds:
+#         await ctx.send(embed=embed)
 
 
 @client.command(name="report", pass_contex=True)
@@ -208,7 +208,7 @@ async def showLeaderboard(ctx, *arg):
 
 @client.command(name="brokenq", aliases=["requeue", "re-q"], pass_contex=True)
 async def removeLastPoppedQueue(ctx):
-    await ctx.send(embed=SixMans.brokenQueue(ctx.message.author))
+    await ctx.send(embed=Admin.brokenQueue(ctx.message.author.roles, ctx.message.mentions))
 
 
 @client.command(name='clear', aliases=['clr', 'reset'], pass_context=True)


### PR DESCRIPTION
Closes #4 
Closes #3 

This work auto assigns random teams when the queue is full and makes the brokenq command an admin only command. Admins must mention a player along with the `!brokenq` command. This is so Norm knows which queue to remove.

Also commented out `pick`, `captains`, and `random` commands so that they could not be used.