### PR TITLE
Fix for !update command

### DIFF
--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -48,18 +48,12 @@ def brokenQueue(roles: List[Role], mentions: List[Member]) -> Embed:
 def update(roles: List[Role]) -> Embed:
     """
         Middleware function to check author's permissions before running the update script.
-
         Parameters:
             roles: List[discord.Role] - The roles of the author of the message.
-
         Returns:
             dicord.Embed - The embedded message to respond with.
     """
     if(Queue.isBotAdmin(roles)):
-        return AdminEmbed(
-            title="Checking For Updates",
-            desc="Please hang tight."
-        )
         updateBot()
         return AdminEmbed(
             title="Already Up to Date",

--- a/src/bot.py
+++ b/src/bot.py
@@ -245,9 +245,13 @@ async def restart(ctx):
     await ctx.send(embed=Admin.restart())
 
 
-@client.command(name='update', pass_context=True)
+@client.command(name="update", pass_context=True)
 async def update(ctx):
-    await ctx.send(embed=Admin.update())
+    await ctx.send(embed=AdminEmbed(
+        title="Checking For Updates",
+        desc="Please hang tight."
+    ))
+    await ctx.send(embed=Admin.update(ctx.message.author.roles))
 
 
 """


### PR DESCRIPTION
Closes #9 

Norm v6.0.0 introduced a bug where the ability to update Norm did not function as expected. 
This update fixes the issue.