### PR TITLE
Admin force report

### DIFF
--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -48,7 +48,7 @@ def brokenQueue(roles: List[Role], mentions: List[Member]) -> Embed:
 
 def forceReport(roles: List[Role], mentions: List[Member], team: str) -> Embed:
     if (Queue.isBotAdmin(roles)):
-        if (len(mentions) == 1):
+        if (len(mentions) == 1 and "<@!" in mentions):
             if (team.lower() == "blue" or team.lower() == "orange"):
                 SixMans.report(mentions, LB_CHANNEL, str.lower())
                 return AdminEmbed(

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -3,7 +3,7 @@ from EmbedHelper import AdminEmbed, ErrorEmbed, QueueUpdateEmbed
 from typing import List
 from Types import Team
 from bot import __version__
-from discord import Role, Embed, Member, channel
+from discord import Role, Embed, Member, channel as Channel
 import Queue
 from Commands.Utils import updateLeaderboardChannel
 from Leaderboard import brokenQueue as breakQueue, reportMatch
@@ -47,7 +47,7 @@ def brokenQueue(roles: List[Role], mentions: List[Member]) -> Embed:
         )
 
 
-async def forceReport(mentions: List[Member], roles: List[Role], lbChannel = channel, *arg) -> Embed:
+async def forceReport(mentions: List[Member], roles: List[Role], lbChannel: Channel, *arg) -> Embed:
     if (Queue.isBotAdmin(roles)):
         if (len(mentions) == 1):
             if (len(arg) == 2 and (str(arg[1]).lower() == Team.BLUE or str(arg[1]).lower() == Team.ORANGE)):

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -53,7 +53,7 @@ async def forceReport(mentions: List[Member], roles: List[Role], *arg) -> Embed:
             if (len(arg) == 2 and (str(arg[1]).lower() == Team.BLUE or str(arg[1]).lower() == Team.ORANGE)):
 
                 player = mentions[0]
-                msg = reportMatch(player, arg[1], 1)
+                msg = reportMatch(player, arg[1], True)
                 
                 if (":x:" in msg):
                     return ErrorEmbed(

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -1,9 +1,10 @@
 from CheckForUpdates import updateBot
 from EmbedHelper import AdminEmbed, ErrorEmbed, QueueUpdateEmbed
 from typing import List
-from bot import __version__
+from bot import __version__, LB_CHANNEL
 from discord import Role, Embed, Member
 import Queue
+import SixMans
 from Leaderboard import brokenQueue as breakQueue
 
 
@@ -42,6 +43,32 @@ def brokenQueue(roles: List[Role], mentions: List[Member]) -> Embed:
         return AdminEmbed(
             title="Permission Denied",
             desc="You do not have the strength to break queues. Ask an admin if you need to break a queue."
+        )
+
+
+def forceReport(roles: List[Role], mentions: List[Member], team: str) -> Embed:
+    if (Queue.isBotAdmin(roles)):
+        if (len(mentions) == 1):
+            if (team.lower() == "blue" or team.lower() == "orange"):
+                SixMans.report(mentions, LB_CHANNEL, str.lower())
+                return AdminEmbed(
+                    title="Match Force Reported Successfully",
+                    desc="You may now re-queue."
+                )
+            else:
+                return ErrorEmbed(
+                    title="You Must Report A Valid Team",
+                    desc="You did not supply a valid team to report."
+                )
+        else:
+            return ErrorEmbed(
+                title="Could Not Report The Match",
+                desc="You must mention one player who is in the match you want to report."
+            )
+    else:
+        return ErrorEmbed(
+            title="Permission Denied",
+            desc="You do not have the strength to force report matches. Ask an admin if you need to force report a match."
         )
 
 

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -3,7 +3,7 @@ from EmbedHelper import AdminEmbed, ErrorEmbed, QueueUpdateEmbed
 from typing import List
 from Types import Team
 from bot import __version__, LB_CHANNEL
-from discord import Role, Embed, Member
+from discord import Role, Embed, Member, channel
 import Queue
 from Commands.Utils import updateLeaderboardChannel
 from Leaderboard import brokenQueue as breakQueue, reportMatch
@@ -47,7 +47,7 @@ def brokenQueue(roles: List[Role], mentions: List[Member]) -> Embed:
         )
 
 
-async def forceReport(mentions: List[Member], roles: List[Role], *arg) -> Embed:
+async def forceReport(mentions: List[Member], roles: List[Role], lbChannel = channel, *arg) -> Embed:
     if (Queue.isBotAdmin(roles)):
         if (len(mentions) == 1):
             if (len(arg) == 2 and (str(arg[1]).lower() == Team.BLUE or str(arg[1]).lower() == Team.ORANGE)):
@@ -65,7 +65,7 @@ async def forceReport(mentions: List[Member], roles: List[Role], *arg) -> Embed:
 
                     try:
                         # if match was reported successfully, update leaderboard channel
-                        await updateLeaderboardChannel(LB_CHANNEL)
+                        await updateLeaderboardChannel(lbChannel)
                     except Exception as e:
                         print("! Norm does not have access to update the leaderboard.", e)
 

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -2,7 +2,7 @@ from CheckForUpdates import updateBot
 from EmbedHelper import AdminEmbed, ErrorEmbed, QueueUpdateEmbed
 from typing import List
 from Types import Team
-from bot import __version__, LB_CHANNEL
+from bot import __version__
 from discord import Role, Embed, Member, channel
 import Queue
 from Commands.Utils import updateLeaderboardChannel

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -54,7 +54,7 @@ async def forceReport(mentions: List[Member], roles: List[Role], *arg) -> Embed:
 
                 player = mentions[0]
                 msg = reportMatch(player, arg[1], 1)
-
+                
                 if (":x:" in msg):
                     return ErrorEmbed(
                         title="Match Not Found",

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -69,7 +69,7 @@ def reportConfirm(player: BallChaser, match: Document, whoWon: Team) -> str:
     return ""
 
 
-def reportMatch(player: Member, whoWon: Team, adminOverride = 0) -> str:
+def reportMatch(player: Member, whoWon: Team, adminOverride = False) -> str:
     global sorted_lb
     match = getActiveMatch(player)
 
@@ -84,7 +84,7 @@ def reportMatch(player: Member, whoWon: Team, adminOverride = 0) -> str:
     )
     msg = reportConfirm(player, match, whoWon)
     
-    if (msg == "" or adminOverride == 1):
+    if (msg == "" or adminOverride == True):
         for key in match:
             if (key != MatchKey.REPORTED_WINNER):
                 teamMember = match[key]

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -69,7 +69,7 @@ def reportConfirm(player: BallChaser, match: Document, whoWon: Team) -> str:
     return ""
 
 
-def reportMatch(player: Member, whoWon: Team, adminOverride = 1) -> str:
+def reportMatch(player: Member, whoWon: Team, adminOverride = 0) -> str:
     global sorted_lb
     match = getActiveMatch(player)
 
@@ -84,7 +84,7 @@ def reportMatch(player: Member, whoWon: Team, adminOverride = 1) -> str:
     )
     msg = reportConfirm(player, match, whoWon)
     
-    if (msg == "" or adminOverride):
+    if (msg == "" or adminOverride == 1):
         for key in match:
             if (key != MatchKey.REPORTED_WINNER):
                 teamMember = match[key]

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -69,7 +69,7 @@ def reportConfirm(player: BallChaser, match: Document, whoWon: Team) -> str:
     return ""
 
 
-def reportMatch(player: Member, whoWon: Team) -> str:
+def reportMatch(player: Member, whoWon: Team, adminOverride = 1) -> str:
     global sorted_lb
     match = getActiveMatch(player)
 
@@ -83,46 +83,48 @@ def reportMatch(player: Member, whoWon: Team) -> str:
         team=foundPlayer[MatchKey.TEAM]
     )
     msg = reportConfirm(player, match, whoWon)
-    if (msg != ""):
+    
+    if (msg == "" or adminOverride):
+        for key in match:
+            if (key != MatchKey.REPORTED_WINNER):
+                teamMember = match[key]
+                if (
+                    (whoWon == Team.BLUE and teamMember["team"] == Team.BLUE) or
+                    (whoWon == Team.ORANGE and teamMember["team"] == Team.ORANGE)
+                ):
+                    win = 1
+                    loss = 0
+                else:
+                    win = 0
+                    loss = 1
+
+                player = leaderboard.get(doc_id=teamMember[MatchKey.ID])
+                if (not player):
+                    leaderboard.insert(Document({
+                        LbKey.ID: teamMember[MatchKey.ID],
+                        LbKey.NAME: teamMember[MatchKey.NAME],
+                        LbKey.WINS: win,
+                        LbKey.LOSSES: loss,
+                        LbKey.MATCHES: 1,
+                        LbKey.WIN_PERC: float(win),
+                    }, doc_id=teamMember[MatchKey.ID]))
+                else:
+                    updated_player = {
+                        LbKey.NAME: teamMember[MatchKey.NAME],
+                        LbKey.WINS: player[LbKey.WINS] + win,
+                        LbKey.LOSSES: player[LbKey.LOSSES] + loss,
+                        LbKey.MATCHES: player[LbKey.MATCHES] + 1,
+                        LbKey.WIN_PERC: player[LbKey.WIN_PERC],
+                    }
+
+                    total_wins = int(updated_player[LbKey.WINS])
+                    total_matches = int(updated_player[LbKey.MATCHES])
+                    updated_player[LbKey.WIN_PERC] = float("{:.2f}".format(total_wins / total_matches))
+
+                    leaderboard.update(updated_player, doc_ids=[player.doc_id])
+
+    elif (msg != ""):
         return msg
-
-    for key in match:
-        if (key != MatchKey.REPORTED_WINNER):
-            teamMember = match[key]
-            if (
-                (whoWon == Team.BLUE and teamMember["team"] == Team.BLUE) or
-                (whoWon == Team.ORANGE and teamMember["team"] == Team.ORANGE)
-            ):
-                win = 1
-                loss = 0
-            else:
-                win = 0
-                loss = 1
-
-            player = leaderboard.get(doc_id=teamMember[MatchKey.ID])
-            if (not player):
-                leaderboard.insert(Document({
-                    LbKey.ID: teamMember[MatchKey.ID],
-                    LbKey.NAME: teamMember[MatchKey.NAME],
-                    LbKey.WINS: win,
-                    LbKey.LOSSES: loss,
-                    LbKey.MATCHES: 1,
-                    LbKey.WIN_PERC: float(win),
-                }, doc_id=teamMember[MatchKey.ID]))
-            else:
-                updated_player = {
-                    LbKey.NAME: teamMember[MatchKey.NAME],
-                    LbKey.WINS: player[LbKey.WINS] + win,
-                    LbKey.LOSSES: player[LbKey.LOSSES] + loss,
-                    LbKey.MATCHES: player[LbKey.MATCHES] + 1,
-                    LbKey.WIN_PERC: player[LbKey.WIN_PERC],
-                }
-
-                total_wins = int(updated_player[LbKey.WINS])
-                total_matches = int(updated_player[LbKey.MATCHES])
-                updated_player[LbKey.WIN_PERC] = float("{:.2f}".format(total_wins / total_matches))
-
-                leaderboard.update(updated_player, doc_ids=[player.doc_id])
 
     activeMatches.remove(doc_ids=[match.doc_id])
     sorted_lb = sorted(leaderboard.all(), key=lambda x: (x[LbKey.WINS], x[LbKey.WIN_PERC]), reverse=True)

--- a/src/bot.py
+++ b/src/bot.py
@@ -225,6 +225,11 @@ async def reportMatch(ctx, *arg):
     await ctx.send(embed=await SixMans.report(ctx.message.author, LB_CHANNEL, *arg))
 
 
+@client.command(name="forceReport", aliases=["fr", "force"], pass_context=True)
+async def forceReport(ctx, *arg):
+    await ctx.send(embed=Admin.forceReport(ctx.message.author.roles, ctx.message.mentions, *arg))
+
+
 @client.command(name="leaderboard", aliases=["lb", "standings", "rank", "rankings", "stonks"], pass_contex=True)
 async def showLeaderboard(ctx, *arg):
     await ctx.send(embed=SixMans.leaderboard(ctx.message.author, ctx.message.mentions, LEADERBOARD_CH_ID, *arg))

--- a/src/bot.py
+++ b/src/bot.py
@@ -227,7 +227,7 @@ async def reportMatch(ctx, *arg):
 
 @client.command(name="forceReport", aliases=["fr", "force"], pass_context=True)
 async def forceReport(ctx, *arg):
-    await ctx.send(embed=Admin.forceReport(ctx.message.author.roles, ctx.message.mentions, *arg))
+    await ctx.send(embed=await Admin.forceReport(ctx.message.mentions, ctx.message.author.roles, *arg))
 
 
 @client.command(name="leaderboard", aliases=["lb", "standings", "rank", "rankings", "stonks"], pass_contex=True)

--- a/src/bot.py
+++ b/src/bot.py
@@ -227,7 +227,7 @@ async def reportMatch(ctx, *arg):
 
 @client.command(name="forceReport", aliases=["fr", "force"], pass_context=True)
 async def forceReport(ctx, *arg):
-    await ctx.send(embed=await Admin.forceReport(ctx.message.mentions, ctx.message.author.roles, *arg))
+    await ctx.send(embed=await Admin.forceReport(ctx.message.mentions, ctx.message.author.roles, LB_CHANNEL, *arg))
 
 
 @client.command(name="leaderboard", aliases=["lb", "standings", "rank", "rankings", "stonks"], pass_contex=True)


### PR DESCRIPTION
Closes #12 

In order to work around the problem that individuals are not allowed to re-queue if one team does not report the match. Admins should be able to override the report and force the match to be reported. This change offers the ability for admins to force a match to be reported by mentioning a player and the team that won.