### PR TITLE
Remove queue start and queue popped pings

### DIFF
--- a/src/Commands/SixMans.py
+++ b/src/Commands/SixMans.py
@@ -48,7 +48,7 @@ def playerQueue(player: Member, reportChannelId: int, *arg) -> PlayerQueueRespon
     elif (queueTime > 60):
         queueTime = 60
 
-    elif (Queue.isPlayerInQueue(player)):
+    if (Queue.isPlayerInQueue(player)):
         Queue.resetPlayerQueueTime(player, queueTime)
         response.embed = QueueUpdateEmbed(
             title="Already in Queue, Queue Time Reset",

--- a/src/Commands/SixMans.py
+++ b/src/Commands/SixMans.py
@@ -14,19 +14,24 @@ from EmbedHelper import \
 from Commands.Utils import generateLobbyDetails, updateLeaderboardChannel, orangeTeamPick, blueTeamPick
 
 
-def playerQueue(player: Member, reportChannelId: int, *arg, quiet: bool = False) -> List[str or Embed]:
+class PlayerQueueResponse:
+    embed = None
+    sendPrivately = False
+
+
+def playerQueue(player: Member, reportChannelId: int, *arg) -> PlayerQueueResponse:
     """
         Adds the author to the Queue for the specified amount of time.
 
         Parameters:
             player: discord.Member - The author of the message. The person being removed from the queue.
             *arg: tuple - The args passed into the client function.
-            quiet: bool (optional, default is False) - Specifies whether to include @here ping in channel.
 
         Returns:
             dicord.Embed - The embedded message to respond with.
     """
     queue_length = Queue.getQueueLength()
+    response = PlayerQueueResponse()
 
     try:
         queueTime = int(arg[0]) if len(arg) > 0 else 60
@@ -44,73 +49,66 @@ def playerQueue(player: Member, reportChannelId: int, *arg, quiet: bool = False)
         queueTime = 60
 
     if (Queue.queueAlreadyPopped()):
-        return [ErrorEmbed(
+        response.embed = ErrorEmbed(
             title="Current Lobby Not Set",
             desc="Please wait until current lobby has been set.",
-        )]
+        )
 
-    if (Queue.isPlayerInQueue(player)):
+    elif (Queue.isPlayerInQueue(player)):
         Queue.resetPlayerQueueTime(player, queueTime)
-        return [QueueUpdateEmbed(
+        response.embed = QueueUpdateEmbed(
             title="Already in Queue, Queue Time Reset",
             desc="You're already in the queue, but your queue time has been reset to {0} minutes.".format(queueTime),
-        )]
+        )
 
-    if (Leaderboard.getActiveMatch(player) is not None):
+    elif (Leaderboard.getActiveMatch(player) is not None):
         if (reportChannelId != -1):
-            return [ErrorEmbed(
+            response.embed = ErrorEmbed(
                 title="Match Still Active",
                 desc="Your previous match has not been reported yet."
                 " Report your match in <#{0}> and try again.".format(reportChannelId),
-            )]
+            )
         else:
-            return [ErrorEmbed(
+            response.embed = ErrorEmbed(
                 title="Match Still Active",
                 desc="Your previous match has not been reported yet."
                 " Report your match and try again.",
-            )]
+            )
 
-    if(queue_length == 0):
+    elif (queue_length == 0):
         Queue.addToQueue(player, queueTime)
 
-        if (quiet):
-            return [QueueUpdateEmbed(
-                title="Queue has Started :shushing_face:",
-                desc="{0} wants to queue!\n\nQueued for {1} minutes.\n\n"
-                "Type **!q** to join".format(player.mention, queueTime),
-            )]
+        response.embed = QueueUpdateEmbed(
+            title="Queue Started",
+            desc="{0} wants to queue!\n\nQueued for {1} minutes.\n\n"
+            "Type **!q** to join".format(player.mention, queueTime),
+        )
 
-        return ["@here Queue has started!",
-                QueueUpdateEmbed(
-                    title="Queue Started",
-                    desc="{0} wants to queue!\n\nQueued for {1} minutes.\n\n"
-                    "Type **!q** to join".format(player.mention, queueTime),
-                )]
-
-    if (queue_length >= 6):
-        return [ErrorEmbed(
+    elif (queue_length >= 6):
+        response.embed = ErrorEmbed(
             title="Queue Already Full",
             desc="Queue is already full, please wait until the current queue is set and try again.",
-        )]
+        )
 
-    if (queue_length == 5):
+    elif (queue_length == 5):
         Queue.addToQueue(player, queueTime)
-
-        mentionedPlayerList = Queue.getQueueList(mentionPlayers=True, separator=", ")
         randomTeamsEmbed = random()
+        response.embed = randomTeamsEmbed
+        response.sendPrivately = True
 
-        return [randomTeamsEmbed, "Queue has popped! Get ready!\n" + mentionedPlayerList]
+    else:
+        Queue.addToQueue(player, queueTime)
+        playerList = Queue.getQueueList()
 
-    Queue.addToQueue(player, queueTime)
-    playerList = Queue.getQueueList()
+        response.embed = QueueUpdateEmbed(
+            title="Player Added to Queue",
+            desc=player.mention + " has been added to the queue for " + str(queueTime) + " minutes."
+        ).add_field(
+            name="Current Queue " + str(queue_length + 1) + "/6",
+            value=playerList
+        )
 
-    return [QueueUpdateEmbed(
-        title="Player Added to Queue",
-        desc=player.mention + " has been added to the queue for " + str(queueTime) + " minutes."
-    ).add_field(
-        name="Current Queue " + str(queue_length + 1) + "/6",
-        value=playerList
-    )]
+    return response
 
 
 def leave(player: Member) -> Embed:

--- a/src/Commands/SixMans.py
+++ b/src/Commands/SixMans.py
@@ -48,12 +48,6 @@ def playerQueue(player: Member, reportChannelId: int, *arg) -> PlayerQueueRespon
     elif (queueTime > 60):
         queueTime = 60
 
-    if (Queue.queueAlreadyPopped()):
-        response.embed = ErrorEmbed(
-            title="Current Lobby Not Set",
-            desc="Please wait until current lobby has been set.",
-        )
-
     elif (Queue.isPlayerInQueue(player)):
         Queue.resetPlayerQueueTime(player, queueTime)
         response.embed = QueueUpdateEmbed(
@@ -82,12 +76,6 @@ def playerQueue(player: Member, reportChannelId: int, *arg) -> PlayerQueueRespon
             title="Queue Started",
             desc="{0} wants to queue!\n\nQueued for {1} minutes.\n\n"
             "Type **!q** to join".format(player.mention, queueTime),
-        )
-
-    elif (queue_length >= 6):
-        response.embed = ErrorEmbed(
-            title="Queue Already Full",
-            desc="Queue is already full, please wait until the current queue is set and try again.",
         )
 
     elif (queue_length == 5):

--- a/src/TestHelper.py
+++ b/src/TestHelper.py
@@ -15,8 +15,8 @@ def fillQueue():
             queueTime=(datetime.now() + timedelta(minutes=60))
         ),
         BallChaser(
-            name="Don#1424",
-            id=528369347807412227,
+            name="QueuePop#4844",
+            id=865024723729383424,
             queueTime=(datetime.now() + timedelta(minutes=60))
         ),
         BallChaser(
@@ -25,18 +25,18 @@ def fillQueue():
             queueTime=(datetime.now() + timedelta(minutes=60))
         ),
         BallChaser(
-            name="daffy#6691",
-            id=209084277223194624,
+            name="FUN Test#5296",
+            id=775074708793327647,
             queueTime=(datetime.now() + timedelta(minutes=60))
         ),
         BallChaser(
-            name="cash#1547",
-            id=347083937216200704,
+            name="Fun Tournaments#7658",
+            id=542718937385795594,
             queueTime=(datetime.now() + timedelta(minutes=60))
         ),
         BallChaser(
-            name="sacrrii#5845",
-            id=616393103322120212,
+            name="Norm at Dreamhack#9296",
+            id=866453980991979520,
             queueTime=(datetime.now() + timedelta(minutes=60))
         ),
     ]

--- a/src/bot.py
+++ b/src/bot.py
@@ -19,7 +19,6 @@ from time import sleep
 from typing import List
 from Commands import EasterEggs, SixMans, Testing, Admin, Utils
 from discord.embeds import Embed
-from Leaderboard import getActiveMatch
 from Queue import getBallChaserList
 
 # Bot prefix and Discord Bot token
@@ -136,48 +135,21 @@ async def stale_queue_timer():
 @client.command(name='q', aliases=['addmepapanorm', 'Q', 'addmebitch', 'queue', 'join'], pass_context=True)
 async def q(ctx, *arg):
     players = getBallChaserList()
-    messages = SixMans.playerQueue(
+    response = SixMans.playerQueue(
         ctx.message.author,
         REPORT_CH_IDS[0] if (len(REPORT_CH_IDS) > 0) else -1,
         *arg,
     )
     author = ctx.message.author
-    for msg in messages:
-        if (isinstance(msg, Embed)):
-            if (getActiveMatch(author) is not None):
-                for i in players:
-                    user = await client.fetch_user(str(i.id))
-                    await user.send(embed=msg)
-                
-                await author.send(embed=msg)
+    if (response.sendPrivately):
+        for i in players:
+            user = await client.fetch_user(str(i.id))
+            if (not user.bot):
+                await user.send(embed=response.embed)
 
-            await ctx.send(embed=msg)
-        else:
-            await ctx.send(msg)
+        await author.send(embed=response.embed)
 
-
-@client.command(name='qq', aliases=['quietq', 'QQ', 'quietqueue', 'shh', 'dontping'], pass_context=True)
-async def qq(ctx, *arg):
-    players = getBallChaserList()
-    messages = SixMans.playerQueue(
-        ctx.message.author,
-        REPORT_CH_IDS[0] if (len(REPORT_CH_IDS) > 0) else -1,
-        *arg,
-        quiet=True
-    )
-    author = ctx.message.author
-    for msg in messages:
-        if (isinstance(msg, Embed)):
-            if (getActiveMatch(author) is not None):
-                for i in players:
-                    user = await client.fetch_user(str(i.id))
-                    await user.send(embed=msg)
-                
-                await author.send(embed=msg)
-
-            await ctx.send(embed=msg)
-        else:
-            await ctx.send(msg)
+    await ctx.send(embed=response.embed)
 
 
 @client.command(name='leave', aliases=['yoink', 'gtfo', 'getmethefuckouttahere'], pass_context=True)

--- a/src/bot.py
+++ b/src/bot.py
@@ -7,6 +7,7 @@ __maintainer__ = "Matt Wells (Tux) / Austin Baker (h)"
 __email__ = "mattwells878@gmail.com / noise.9no@gmail.com"
 __credits__ = "Forked from https://github.com/ClamSageCaleb/UNCC-SIX-MANS to be modified for UNCC event with Dreamhack."
 
+import asyncio
 import AWSHelper as AWS
 from DataFiles import getDiscordToken, updateDiscordToken, getChannelIds
 from EmbedHelper import ErrorEmbed, AdminEmbed, HelpEmbed
@@ -142,12 +143,14 @@ async def q(ctx, *arg):
     )
     author = ctx.message.author
     if (response.sendPrivately):
-        for i in players:
-            user = await client.fetch_user(str(i.id))
+        async def sendPrivateMsg(playerId: str):
+            user = await client.fetch_user(playerId)
             if (not user.bot):
                 await user.send(embed=response.embed)
 
-        await author.send(embed=response.embed)
+        players.append(author)
+        # perform each async task synchronously since we don't care about order of completion
+        await asyncio.wait([sendPrivateMsg(str(p.id)) for p in players])
 
     await ctx.send(embed=response.embed)
 


### PR DESCRIPTION
Closes #14 

This work removes the `@here` when a queue starts and removes the pings after a queue has popped. 

Swapped real users with bots to stop accidently bothering people.

Batched async teams set private DMs for better performance.